### PR TITLE
Normalize flags

### DIFF
--- a/flow/util.go
+++ b/flow/util.go
@@ -21,11 +21,55 @@ func Run(cmd cli.Command) error {
 	if err := fSet.Parse(os.Args[1:]); err != nil {
 		return errors.Trace(err)
 	}
+	if err := normalizeFlags(cmd.Flags, fSet); err != nil {
+		return errors.Trace(err)
+	}
 
 	ctx := cli.NewContext(nil, fSet, nil)
 
 	cmd.Action.(func(*cli.Context))(ctx)
 	return nil
+}
+
+func normalizeFlags(flags []cli.Flag, set *flag.FlagSet) error {
+	visited := make(map[string]bool)
+	set.Visit(func(f *flag.Flag) {
+		visited[f.Name] = true
+	})
+	for _, f := range flags {
+		parts := strings.Split(f.GetName(), ",")
+		if len(parts) == 1 {
+			continue
+		}
+		var ff *flag.Flag
+		for _, name := range parts {
+			name = strings.Trim(name, " ")
+			if visited[name] {
+				if ff != nil {
+					return errors.New("Cannot use two forms of the same flag: " + name + " " + ff.Name)
+				}
+				ff = set.Lookup(name)
+			}
+		}
+		if ff == nil {
+			continue
+		}
+		for _, name := range parts {
+			name = strings.Trim(name, " ")
+			if !visited[name] {
+				copyFlag(name, ff, set)
+			}
+		}
+	}
+	return nil
+}
+
+func copyFlag(name string, ff *flag.Flag, set *flag.FlagSet) {
+	switch ff.Value.(type) {
+	case *cli.StringSlice:
+	default:
+		set.Set(name, ff.Value.String())
+	}
 }
 
 // TODO(waigani) move this to codelingo/sdk/flow


### PR DESCRIPTION
Joins short and long flags so that the lookup points to the same result; ie. `-k` and `--keep-all` match the same value.